### PR TITLE
Add initial support for creating Invoice Items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ deps/
 ebin/
 tags
 priv/currencies.json
+.rebar/

--- a/src/stripe.app.src
+++ b/src/stripe.app.src
@@ -1,7 +1,7 @@
 {application, stripe,
  [
   {description, "stripe - erlang stripe.com API access"},
-  {vsn, "0.7.1"},
+  {vsn, "0.7.2"},
   {modules, []},
   {applications, [
                   kernel,

--- a/src/stripe.erl
+++ b/src/stripe.erl
@@ -7,6 +7,7 @@
 -export([customer/1, event/1, invoiceitem/1]).
 -export([recipient_create/6, recipient_update/6]).
 -export([transfer_create/5, transfer_cancel/1]).
+-export([invoiceitem_create/4]).
 
 -include("stripe.hrl").
 
@@ -153,6 +154,13 @@ customer(CustomerId) ->
 invoiceitem(InvoiceItemId) ->
   request_invoiceitem(InvoiceItemId).
 
+invoiceitem_create(Customer, Amount, Currency, Description) ->
+    Fields = [{customer, Customer},
+              {amount, Amount},
+              {currency, Currency},
+              {description, Description}],
+    request_invoiceitem_create(Fields).
+
 %%%--------------------------------------------------------------------
 %%% request generation and sending
 %%%--------------------------------------------------------------------
@@ -167,6 +175,9 @@ request_customer(CustomerId) ->
 
 request_invoiceitem(InvoiceItemId) ->
   request_run(gen_invoiceitem_url(InvoiceItemId), get, []).
+
+request_invoiceitem_create(Fields) ->
+  request(invoiceitems, post, Fields).
 
 request_customer_create(Fields) ->
   request(customers, post, Fields).
@@ -499,7 +510,7 @@ gen_transfer_cancel_url(TransferId) when is_list(TransferId) ->
   "https://api.stripe.com/v1/transfers/" ++ TransferId ++ "/cancel".
 
 gen_invoiceitem_url(InvoiceItemId) when is_binary(InvoiceItemId) ->
-  gen_customer_url(binary_to_list(InvoiceItemId));
+  gen_invoiceitem_url(binary_to_list(InvoiceItemId));
 gen_invoiceitem_url(InvoiceItemId) when is_list(InvoiceItemId) ->
   "https://api.stripe.com/v1/invoiceitems/" ++ InvoiceItemId.
 


### PR DESCRIPTION
This adds `stripe:invoiceitem_create` as well as tests for that
functionality. In addition a bug in the existing
`stripe:invoiceitem` function was found and fixed.
